### PR TITLE
fix vitamins navbar

### DIFF
--- a/app/views/vitamins/index.html.erb
+++ b/app/views/vitamins/index.html.erb
@@ -1,4 +1,4 @@
-<%= provide :title, "My Vitamins Intake" %>
+<%= provide :title, "Vitamins Intake" %>
 <div class="container">
   <div class="justify-content-center row mt-4">
     <% @created = @vitamins %>


### PR DESCRIPTION
Chaged the title to "Vitmains Intake" so it won't wrap and it does not break the navbar menu

![image](https://user-images.githubusercontent.com/22175790/205647873-94fb71d4-7e98-445a-b967-6fd86587e877.png)
